### PR TITLE
fix(layout): reduce implicit row size

### DIFF
--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -38,6 +38,9 @@ const { links, class: className } = Astro.props;
     list-style: none;
     display: flex;
   }
+  nav > ul {
+    margin-bottom: 0;
+  }
   .hamburger {
     display: none;
   }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -31,6 +31,7 @@ a[href]:visited {
 .app-grid {
   display: grid;
   grid-template-columns: var(--grid-columns);
+  grid-template-rows: min-content;
 }
 .app-grid > * {
   grid-column: var(--grid-column);
@@ -38,4 +39,8 @@ a[href]:visited {
 
 body {
   overflow-y: scroll;
+}
+
+header {
+  margin-bottom: var(--size-7);
 }


### PR DESCRIPTION
## Summary

- set the size of grid rows to the minimum content size
- remove default `<ul>` margin for the list of links in the header and apply the spacing to the `<header>` instead

## Why set `grid-template-rows: min-content`

By default, implicit (auto generated) rows will grow to take up the available size. If there's minimal content in the page, then the header row will grow in size:

<img width="1080" alt="image" src="https://github.com/chrisvaillancourt/website/assets/44307925/f6797eed-ccb1-4490-8a31-bf55009e17ab">

If there's a lot of content on the page then this doesn't matter:

<img width="1080" alt="image" src="https://github.com/chrisvaillancourt/website/assets/44307925/d6966c32-d3fe-457e-8b3f-5e4b632ea8a8">


After setting  `grid-template-rows: min-content`, the header doesn't grow in size on pages with minimal content:

<img width="1080" alt="image" src="https://github.com/chrisvaillancourt/website/assets/44307925/c71ec3fe-9bd4-4582-8106-7296dcbedbca">

