### PR TITLE
Fix/65/prod styles

### DIFF
--- a/src/components/Btn.astro
+++ b/src/components/Btn.astro
@@ -12,5 +12,5 @@ const { class: className = '' } = Astro.props;
 </button>
 
 <style>
-  @import 'open-props/buttons' layer(components-btn);
+  @import '@/styles/btn.css';
 </style>

--- a/src/components/Link.astro
+++ b/src/components/Link.astro
@@ -16,5 +16,5 @@ const {
 </a>
 
 <style>
-  @import '@/styles/link.css' layer(components-link);
+  @import '@/styles/link.css';
 </style>

--- a/src/pages/posts/[...slug].astro
+++ b/src/pages/posts/[...slug].astro
@@ -23,5 +23,5 @@ const { Content } = await post.render();
 </PostLayout>
 
 <style>
-  @import '@/styles/link.css' layer(components-link);
+  @import '@/styles/link.css';
 </style>

--- a/src/pages/posts/[...slug].astro
+++ b/src/pages/posts/[...slug].astro
@@ -22,6 +22,7 @@ const { Content } = await post.render();
   <Content />
 </PostLayout>
 
-<style>
+<style is:global>
+  /* Needs to be global to apply link styles */
   @import '@/styles/link.css';
 </style>

--- a/src/styles/btn.css
+++ b/src/styles/btn.css
@@ -1,1 +1,1 @@
-@import 'open-props/buttons' layer(components-btn);
+@import 'open-props/buttons';

--- a/src/styles/btn.css
+++ b/src/styles/btn.css
@@ -1,0 +1,1 @@
+@import 'open-props/buttons' layer(components-btn);

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,4 +1,4 @@
-@layer normalize, theme, components-btn, components-link;
+@layer normalize, theme;
 @import './normalize.css' layer(normalize);
 @import './theme.css' layer(theme);
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,3 +1,4 @@
+@layer normalize, theme, components-btn, components-link;
 @import './normalize.css' layer(normalize);
 @import './theme.css' layer(theme);
 

--- a/src/styles/link.css
+++ b/src/styles/link.css
@@ -1,20 +1,18 @@
-@layer components-link {
-  a[href],
-  a[href] * {
-    text-decoration: none;
-  }
-  a[href],
-  a[href]:visited {
-    color: var(--link);
-  }
-  a[href]:hover {
-    text-decoration: underline solid var(--link);
-    background-color: hsl(var(--brand-hsl) / 20%);
-  }
-  a[href] *:hover {
-    text-decoration: underline solid var(--link) 0;
-  }
-  a[href] > code:hover {
-    background-color: transparent;
-  }
+a[href],
+a[href] * {
+  text-decoration: none;
+}
+a[href],
+a[href]:visited {
+  color: var(--link);
+}
+a[href]:hover {
+  text-decoration: underline solid var(--link);
+  background-color: hsl(var(--brand-hsl) / 20%);
+}
+a[href] *:hover {
+  text-decoration: underline solid var(--link) 0;
+}
+a[href] > code:hover {
+  background-color: transparent;
 }

--- a/src/styles/link.css
+++ b/src/styles/link.css
@@ -1,18 +1,20 @@
-a[href],
-a[href] * {
-  text-decoration: none;
-}
-a[href],
-a[href]:visited {
-  color: var(--link);
-}
-a[href]:hover {
-  text-decoration: underline solid var(--link);
-  background-color: hsl(var(--brand-hsl) / 20%);
-}
-a[href] *:hover {
-  text-decoration: underline solid var(--link) 0;
-}
-a[href] > code:hover {
-  background-color: transparent;
+@layer components-link {
+  a[href],
+  a[href] * {
+    text-decoration: none;
+  }
+  a[href],
+  a[href]:visited {
+    color: var(--link);
+  }
+  a[href]:hover {
+    text-decoration: underline solid var(--link);
+    background-color: hsl(var(--brand-hsl) / 20%);
+  }
+  a[href] *:hover {
+    text-decoration: underline solid var(--link) 0;
+  }
+  a[href] > code:hover {
+    background-color: transparent;
+  }
 }


### PR DESCRIPTION
## Summary

- remove custom cascade layers in order to apply correct link and button styles
  - resolves #65
 
### Discussion

We can't use layers because there are style conflicts between custom link styles and styles in `normalize.css`. Removing the layers resolves all styling issues.

We also can't use class scoping strategy due to https://github.com/withastro/astro/issues/7282.