### PR TITLE
refactor: use chris instead of christopher

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "christopher-vaillancourt-website",
+  "name": "chris-vaillancourt-website",
   "version": "0.0.1",
-  "description": "Christopher Vaillancourt's personal website.",
+  "description": "Chris Vaillancourt's personal website.",
   "type": "module",
   "scripts": {
     "dev": "astro check --watch & astro dev --host",

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -39,10 +39,7 @@ const navLinks = [
       href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🐢</text></svg>"
     />
     <meta name="generator" content={Astro.generator} />
-    <meta
-      name="description"
-      content="Christopher Vaillancourt's personal website"
-    />
+    <meta name="description" content="Chris Vaillancourt's personal website" />
     <title>{title}</title>
   </head>
   <body class="app-grid">

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -3,7 +3,7 @@ import BaseLayout from '@/layouts/BaseLayout.astro';
 import Link from '@/components/Link.astro';
 ---
 
-<BaseLayout title="Not Found Christopher Vaillancourt">
+<BaseLayout title="Not Found Chris Vaillancourt">
   <article>
     <h1>404</h1>
     <p>Oops, this page doesn't exist.</p>

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -5,7 +5,7 @@ import Link from '@/components/Link.astro';
 import { linkedIn, github } from '@/lib/icons';
 ---
 
-<BaseLayout title="About Christopher Vaillancourt">
+<BaseLayout title="About Chris Vaillancourt">
   <article>
     <h1>About</h1>
     <section>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -6,9 +6,9 @@ import PostsList from '@/components/PostsList.astro';
 const recentPosts = (await publishedPostsByDate()).slice(0, 3);
 ---
 
-<BaseLayout title="Christopher Vaillancourt">
+<BaseLayout title="Chris Vaillancourt">
   <article class="intro">
-    <h1>Christopher Vaillancourt</h1>
+    <h1>Chris Vaillancourt</h1>
     <h2>Full stack software engineer</h2>
   </article>
   <article>

--- a/src/pages/posts/index.astro
+++ b/src/pages/posts/index.astro
@@ -8,7 +8,7 @@ import DateTime from '@/components/DateTime.astro';
 const posts = await getPublishedPosts();
 ---
 
-<BaseLayout title="Christopher Vaillancourt's Posts" class="posts">
+<BaseLayout title="Chris Vaillancourt's Posts" class="posts">
   <h1>Posts</h1>
   <ul>
     {


### PR DESCRIPTION
## Summary

- Use "Chris" instead of "Christopher"
  - improves consistency between domain name and website copy
  - resolves #64