### PR TITLE
[codex] Migrate pnpm config to v11.3.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
 
       - name: Install Playwright browsers
         run:
-          pnpm exec playwright install --with-deps chromium
+          ./node_modules/.bin/playwright install --with-deps chromium
           chromium-headless-shell
 
       - name: Build site

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,9 +54,7 @@ jobs:
         uses: ./.github/actions/setup
 
       - name: Install Playwright browsers
-        run:
-          ./node_modules/.bin/playwright install --with-deps chromium
-          chromium-headless-shell
+        run: ./node_modules/.bin/playwright install --with-deps chromium
 
       - name: Build site
         run: pnpm build

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -11,6 +11,7 @@ on:
       - '.github/workflows/docker.yml'
       - 'package.json'
       - 'pnpm-lock.yaml'
+      - 'pnpm-workspace.yaml'
   pull_request:
     branches: [main]
     paths:
@@ -21,6 +22,7 @@ on:
       - '.github/workflows/docker.yml'
       - 'package.json'
       - 'pnpm-lock.yaml'
+      - 'pnpm-workspace.yaml'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,0 @@
-# Expose Astro dependencies for `pnpm` users
-shamefully-hoist=true

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@
 #   production  - Serve production build
 
 ARG NODE_VERSION=24
-ARG PNPM_VERSION=10.29.2
+ARG PNPM_VERSION=11.3.0
 
 # --- base: Node.js + pnpm ---------------------------------------------------
 FROM node:${NODE_VERSION}-slim AS base
@@ -33,12 +33,12 @@ RUN pnpm config set store-dir /pnpm/store
 # --- deps: install dependencies ---------------------------------------------
 FROM base AS deps
 
-COPY pnpm-lock.yaml ./
+COPY pnpm-lock.yaml pnpm-workspace.yaml ./
 RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm fetch
 
 COPY package.json ./
 RUN --mount=type=cache,id=pnpm,target=/pnpm/store \
-    pnpm install --offline --frozen-lockfile
+    CI=true pnpm install --offline --frozen-lockfile
 
 # --- development: full dev environment ---------------------------------------
 FROM base AS development

--- a/Dockerfile
+++ b/Dockerfile
@@ -83,8 +83,9 @@ RUN pnpm config set store-dir /home/node/.local/share/pnpm/store
 
 COPY --from=deps --chown=node:node /app/node_modules ./node_modules
 COPY --from=deps --chown=node:node /app/package.json ./
+COPY --from=deps --chown=node:node /app/pnpm-workspace.yaml ./
 
-RUN pnpm exec playwright install --with-deps chromium chromium-headless-shell firefox webkit
+RUN CI=true pnpm exec playwright install --with-deps chromium chromium-headless-shell firefox webkit
 
 EXPOSE 4321
 CMD ["pnpm", "run", "dev"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -85,7 +85,7 @@ COPY --from=deps --chown=node:node /app/node_modules ./node_modules
 COPY --from=deps --chown=node:node /app/package.json ./
 COPY --from=deps --chown=node:node /app/pnpm-workspace.yaml ./
 
-RUN CI=true pnpm exec playwright install --with-deps chromium chromium-headless-shell firefox webkit
+RUN CI=true ./node_modules/.bin/playwright install --with-deps chromium chromium-headless-shell firefox webkit
 
 EXPOSE 4321
 CMD ["pnpm", "run", "dev"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -85,7 +85,7 @@ COPY --from=deps --chown=node:node /app/node_modules ./node_modules
 COPY --from=deps --chown=node:node /app/package.json ./
 COPY --from=deps --chown=node:node /app/pnpm-workspace.yaml ./
 
-RUN CI=true ./node_modules/.bin/playwright install --with-deps chromium chromium-headless-shell firefox webkit
+RUN CI=true ./node_modules/.bin/playwright install --with-deps chromium firefox webkit
 
 EXPOSE 4321
 CMD ["pnpm", "run", "dev"]

--- a/compose.yaml
+++ b/compose.yaml
@@ -6,7 +6,7 @@
 
 x-build-args: &build-args
   NODE_VERSION: '24'
-  PNPM_VERSION: '10.29.2'
+  PNPM_VERSION: '11.3.0'
 
 services:
   # Development with hot reloading

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"version": "0.0.1",
 	"description": "Chris Vaillancourt's personal website.",
 	"type": "module",
-	"packageManager": "pnpm@10.29.2",
+	"packageManager": "pnpm@11.3.0",
 	"scripts": {
 		"preinstall": "npx only-allow pnpm",
 		"dev": "astro check --watch & astro dev --host",
@@ -53,10 +53,5 @@
 		"satori-html": "^0.3.2",
 		"sharp": "^0.34.5",
 		"zod": "^3.24.2"
-	},
-	"pnpm": {
-		"onlyBuiltDependencies": [
-			"sharp"
-		]
 	}
 }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
 		"@astrojs/mdx": "^4.0.8",
 		"@astrojs/sitemap": "^3.2.1",
 		"@astrojs/tailwind": "^6.0.0",
-		"@playwright/test": "^1.50.1",
+		"@playwright/test": "^1.60.0",
 		"@resvg/resvg-js": "^2.6.2",
 		"@tailwindcss/aspect-ratio": "^0.4.2",
 		"@tailwindcss/typography": "^0.5.16",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -52,8 +52,8 @@ importers:
         specifier: ^6.0.0
         version: 6.0.0(astro@5.3.0(@types/node@22.13.4)(jiti@1.21.7)(rollup@4.34.8)(typescript@5.7.3)(yaml@2.7.0))(tailwindcss@3.4.17)
       '@playwright/test':
-        specifier: ^1.50.1
-        version: 1.50.1
+        specifier: ^1.60.0
+        version: 1.60.0
       '@resvg/resvg-js':
         specifier: ^2.6.2
         version: 2.6.2
@@ -860,8 +860,8 @@ packages:
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
 
-  '@playwright/test@1.50.1':
-    resolution: {integrity: sha512-Jii3aBg+CEDpgnuDxEp/h7BimHcUTDlpEtce89xEumlJ5ef2hqepZ+PWp1DDpYC/VO9fmWVI1IlEaoI5fK9FXQ==}
+  '@playwright/test@1.60.0':
+    resolution: {integrity: sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -1142,6 +1142,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@vitest/expect@3.0.6':
     resolution: {integrity: sha512-zBduHf/ja7/QRX4HdP1DSq5XrPgdN+jzLOwaTq/0qZjYfgETNFCKf9nOAp2j3hmom3oTbczuUzrzg9Hafh7hNg==}
@@ -1746,6 +1747,7 @@ packages:
 
   glob@10.4.5:
     resolution: {integrity: sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
   graceful-fs@4.2.11:
@@ -2320,13 +2322,13 @@ packages:
   pkg-types@1.3.1:
     resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
 
-  playwright-core@1.50.1:
-    resolution: {integrity: sha512-ra9fsNWayuYumt+NiM069M6OkcRb1FZSK8bgi66AtpFoWkg2+y0bJSNmkFrWhMbEBbVKC/EruAHH3g0zmtwGmQ==}
+  playwright-core@1.60.0:
+    resolution: {integrity: sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==}
     engines: {node: '>=18'}
     hasBin: true
 
-  playwright@1.50.1:
-    resolution: {integrity: sha512-G8rwsOQJ63XG6BbKj2w5rHeavFjy5zynBA9zsJMMtBoe/Uf757oG12NXz6e6OirF7RCrTVAKFXbLmn1RbL7Qaw==}
+  playwright@1.60.0:
+    resolution: {integrity: sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -2664,6 +2666,7 @@ packages:
   sitemap@8.0.0:
     resolution: {integrity: sha512-+AbdxhM9kJsHtruUF39bwS/B0Fytw6Fr1o4ZAIAEqA6cke2xcoO2GleBw9Zw7nRzILVEgz7zBM5GiTJjie1G9A==}
     engines: {node: '>=14.0.0', npm: '>=6.0.0'}
+    deprecated: 'SECURITY: Multiple vulnerabilities fixed in 8.0.1 (XML injection, path traversal, command injection, protocol injection). Upgrade immediately: npm install sitemap@8.0.1'
     hasBin: true
 
   smol-toml@1.3.1:
@@ -2740,6 +2743,7 @@ packages:
 
   strnum@1.1.0:
     resolution: {integrity: sha512-a4NGarQIHRhvr+k8VXaHg6TMU6f3YEmi5CAb6RYgX2gwbGDBNMbr6coC6g0wmif5dLjHtmHUVD/qOxPq7D0tnQ==}
+    deprecated: This version introduces bugs
 
   style-to-object@1.0.8:
     resolution: {integrity: sha512-xT47I/Eo0rwJmaXC4oilDGDWLohVhR6o/xAQcPQN8q6QBuZVL8qMYL85kLmST5cPjAorwvqIA4qXTRQoYHaL6g==}
@@ -3882,9 +3886,9 @@ snapshots:
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
-  '@playwright/test@1.50.1':
+  '@playwright/test@1.60.0':
     dependencies:
-      playwright: 1.50.1
+      playwright: 1.60.0
 
   '@resvg/resvg-js-android-arm-eabi@2.6.2':
     optional: true
@@ -5741,11 +5745,11 @@ snapshots:
       mlly: 1.7.4
       pathe: 2.0.3
 
-  playwright-core@1.50.1: {}
+  playwright-core@1.60.0: {}
 
-  playwright@1.50.1:
+  playwright@1.60.0:
     dependencies:
-      playwright-core: 1.50.1
+      playwright-core: 1.60.0
     optionalDependencies:
       fsevents: 2.3.2
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+shamefullyHoist: true
+allowBuilds:
+  sharp: true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,5 @@
 shamefullyHoist: true
 allowBuilds:
+  esbuild: true
   sharp: true
+  workerd: true


### PR DESCRIPTION
## Summary
- update the package manager pin to pnpm 11.3.0
- move pnpm-specific config from .npmrc/package.json into pnpm-workspace.yaml
- configure pnpm v11 allowBuilds for sharp, esbuild, and workerd
- align Docker and Compose with pnpm 11.3.0 and include pnpm-workspace.yaml in Docker dependency layers
- update Playwright to 1.60.0 so browser installation works reliably under Node 24

## Validation
- CI / Lint & Type Check
- CI / Unit Tests
- CI / E2E Tests
- CI / Build
- Docker / Verify Docker Compose
- Docker / Build development Image
- Docker / Build production Image
- Docker / Build test Image
- local: CI=true sfw pnpm install --frozen-lockfile
- local: pnpm build
- local: pnpm test run
- local: pnpm test:e2e --project=chromium
- local: docker build --target development --progress=plain .
