### PR TITLE
chore: configure shared Mnemopi memory bank

### DIFF
--- a/.omp/config.yml
+++ b/.omp/config.yml
@@ -1,0 +1,3 @@
+mnemopi:
+  bank: chrisvaillancourt-website
+  scoping: global


### PR DESCRIPTION
## Summary

- Configures an explicitly isolated Mnemopi bank for this repository while sharing it among worktrees whose checked-out commit contains this configuration.
- Existing branches and worktrees gain this override only after normal integration of the configuration.
- This configuration is only for the [OMP agent harness](https://omp.sh).

## Effective configuration

- `memory.backend = mnemopi` (inherited and untracked)
- `mnemopi.bank = chrisvaillancourt-website`
- `mnemopi.scoping = global`